### PR TITLE
explicitly join default params into string

### DIFF
--- a/lib/less/js_routes.rb
+++ b/lib/less/js_routes.rb
@@ -42,7 +42,7 @@ module Less
             end
           end
         end
-        s
+        s.join(" ")
       end
 
       def build_path segs


### PR DESCRIPTION
Ruby 1.8 implicitly joins arrays when interpolated. Ruby 1.9.x does not. This causes every route to break on 1.9:

```
["format = less_check_format(format);"]
```

instead of:

```
format = less_check_format(format);
```

This patch is a quick fix, joining the array.
